### PR TITLE
Fulfill only pending orders and choose supplier

### DIFF
--- a/app/jobs/fulfill_orders_job.rb
+++ b/app/jobs/fulfill_orders_job.rb
@@ -1,14 +1,56 @@
+require 'supplier_bar_api/client'
 require 'supplier_foo_api/client'
 
 class FulfillOrdersJob < ApplicationJob
   queue_as :default
 
   def perform(*args)
-    supplier = Supplier.find_by!(name: 'supplier_foo')
-
-    Order.all.each do |order|
-      reference = SupplierFooApi::Client.fulfill(product_name: order.product.name)
-      order.update!(supplier: supplier, supplier_reference: reference)
+    Order.transaction do
+      Order.pending.each do |order|
+        fulfill_order(order)
+      end
     end
+  end
+
+  private
+
+  def fulfill_order(order)
+    Rails.logger.info "Fulfilling to fulfill order for #{order.customer_name}"
+
+    fulfilling_supplier = order_fulfilling_supplier(order)
+
+    if fulfilling_supplier
+      reference = get_api_client(fulfilling_supplier).fulfill(product_name: order.product.name)
+
+      order.update(
+        supplier: fulfilling_supplier,
+        supplier_reference: reference,
+        state: 'completed'
+      )
+    else
+      Rails.logger.info "Could not find a supplier with stock to fulfill order for #{order.customer_name}".alarmify
+    end
+  end
+
+  def order_fulfilling_supplier(order)
+    Supplier.all.find do |supplier|
+      stock = get_api_client(supplier).stock(product_name: order.product.name)
+      stock.positive?
+    end
+  end
+
+  def get_api_client(supplier)
+    [
+      [supplier_foo, SupplierFooApi::Client],
+      [supplier_bar, SupplierBarApi::Client]
+    ].find { |e| e[0] == supplier }.last
+  end
+
+  def supplier_foo
+    Supplier.find_by(name: 'supplier_foo')
+  end
+
+  def supplier_bar
+    Supplier.find_by(name: 'supplier_bar')
   end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -3,4 +3,7 @@ class Order < ApplicationRecord
   belongs_to :supplier, optional: true
 
   validates :customer_name, presence: true
+
+  scope :pending, -> { where(state: 'pending') }
+  # scope :completed, -> { where(state: 'completed') }
 end

--- a/config/initializers/string_monkey_patch.rb
+++ b/config/initializers/string_monkey_patch.rb
@@ -1,0 +1,5 @@
+class String
+  def alarmify
+    "\e[31m#{self}\e[0m"
+  end
+end

--- a/db/migrate/20210513172112_add_state_to_orders.rb
+++ b/db/migrate/20210513172112_add_state_to_orders.rb
@@ -1,0 +1,5 @@
+class AddStateToOrders < ActiveRecord::Migration[6.1]
+  def change
+    add_column :orders, :state, :string, default: 'pending'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_13_143700) do
+ActiveRecord::Schema.define(version: 2021_05_13_172112) do
 
   create_table "orders", force: :cascade do |t|
     t.string "customer_name", null: false
@@ -19,6 +19,7 @@ ActiveRecord::Schema.define(version: 2021_05_13_143700) do
     t.datetime "updated_at", precision: 6, null: false
     t.integer "supplier_id"
     t.string "supplier_reference"
+    t.string "state", default: "pending"
     t.index ["product_id"], name: "index_orders_on_product_id"
     t.index ["supplier_id"], name: "index_orders_on_supplier_id"
   end

--- a/spec/jobs/fulfill_orders_job_spec.rb
+++ b/spec/jobs/fulfill_orders_job_spec.rb
@@ -4,32 +4,58 @@ RSpec.describe FulfillOrdersJob, type: :job do
   describe '#perform' do
     subject { job.perform }
 
+
     let(:job) { described_class.new }
 
-    before do
-      Order.create(customer_name: 'Orlando Bloom', product: Product.create( name: 'Fancy Headphones'))
-      Order.create(customer_name: 'Dua Lipa', product: Product.create(name: 'Cool Smartphone'))
-    end
+    let!(:order_one) { Order.create(customer_name: 'Lionel Messi', product: Product.create( name: 'Golden Boot')) }
+    let!(:order_two) { Order.create(customer_name: 'Cristiano Ronaldo', product: Product.create(name: 'Balon d Or')) }
+    let!(:order_three) { Order.create(customer_name: 'Kylian Mbappe', product: Product.create(name: 'Turtle Ninja Figurine')) }
 
-    context 'when the supplier does not exist' do
-      it 'raises an error' do
-        expect { subject }.to raise_error(ActiveRecord::RecordNotFound, "Couldn't find Supplier")
-      end
-
+    context 'when there are no suppliers' do
       it 'does not change any orders' do
-        expect do
-          subject rescue ActiveRecord::RecordNotFound
-        end.not_to(change { Order.all.map(&:attributes) })
+        expect { subject }.not_to(change { Order.all.map(&:attributes) })
       end
     end
 
-    context 'when the supplier exists' do
-      let!(:supplier) { Supplier.create(name: 'supplier_foo') }
+    context 'when there are some suppliers' do
+      let!(:supplier_foo) { Supplier.create(name: 'supplier_foo') }
+      let!(:supplier_bar) { Supplier.create(name: 'supplier_bar') }
 
-      it 'updates all orders with the supplier and the supplier reference' do
-        expect { subject }.to change { Order.all.pluck(:supplier_id, :supplier_reference) }
-          .from([[nil, nil], [nil, nil]])
-          .to([[supplier.id, an_instance_of(String)], [supplier.id, an_instance_of(String)]])
+      context 'but none of them have stock for the orders' do
+        before do
+          allow(SupplierFooApi::Client).to receive(:stock).and_return(0)
+          allow(SupplierBarApi::Client).to receive(:stock).and_return(0)
+        end
+
+        it 'does not change any orders' do
+          expect { subject }.not_to(change { Order.all.map(&:attributes) })
+        end
+      end
+
+      context 'and not all orders can be fulfilled by a supplier' do
+        let(:supplier_foo_reference) { SecureRandom.uuid }
+        let(:supplier_bar_reference) { SecureRandom.uuid }
+
+        before do
+          allow(SupplierFooApi::Client).to receive(:stock).and_return(3, 0, 0)
+          allow(SupplierBarApi::Client).to receive(:stock).and_return(7, 0)
+          allow(SupplierFooApi::Client).to receive(:fulfill).and_return(supplier_foo_reference)
+          allow(SupplierBarApi::Client).to receive(:fulfill).and_return(supplier_bar_reference)
+        end
+
+        it 'updates all orders with the supplier and the supplier reference' do
+          expect { subject }.to change { Order.all.pluck(:supplier_id, :supplier_reference, :state) }
+            .from([[nil, nil, 'pending'], [nil, nil, 'pending'], [nil, nil, 'pending']])
+            .to([[supplier_foo.id, supplier_foo_reference, 'completed'], [supplier_bar.id, supplier_bar_reference, 'completed'], [nil, nil, 'pending']])
+        end
+
+        it 'completes the correct number of orders' do
+          expect { subject }.to change { Order.where(state: 'completed').count }.by(2)
+          expect(Order.count).to eq(3)
+
+          expect(order_one.updated_at.round).to eq(Time.current.round)
+          expect(order_three.updated_at.round).to eq(Time.current.round)
+        end
       end
     end
   end


### PR DESCRIPTION
# Backstory

The app currently fulfills orders with a single supplier.

In terms of data models the app has the following:
* Product
* Order (has one product)
* Supplier (the entity that will fulfill the order)

It has a background job that is responsible for processing orders that need fulfilling.

# PR Goal

* Fulfill only pending orders
* For each order, choose the supplier that has stock for the order's product

# Review guidelines

Please go through all the PR changes and leave a PR review that includes whether the code is ready to merge and any points that need refinements.

**HINT:** We have planted several traps of varying importance in this PR's code. Don't worry about making a large number of comments, if you find all those traps.

**NOTE:** The supplier API clients are mocks. They're not part of the review process but their behaviour might affect the outcome of the job.
